### PR TITLE
fix Il2CppMetadataUsagePair to Il2CppMetadataUsageList

### DIFF
--- a/unity_decoder/main.cpp
+++ b/unity_decoder/main.cpp
@@ -300,7 +300,7 @@ int main()
 
 
 	stringLiteralFile.open(StringLiteralFileName);
-	int usagePairCount = s_GlobalMetadataHeader->metadataUsageListsCount / sizeof(Il2CppMetadataUsagePair);
+	int usagePairCount = s_GlobalMetadataHeader->metadataUsageListsCount / sizeof(Il2CppMetadataUsageList);
 	for (int i = 0; i < usagePairCount; i++) {
 		InitializeMethodMetadata(i);
 	}

--- a/unity_decoder/main.cpp
+++ b/unity_decoder/main.cpp
@@ -300,8 +300,8 @@ int main()
 
 
 	stringLiteralFile.open(StringLiteralFileName);
-	int usagePairCount = s_GlobalMetadataHeader->metadataUsageListsCount / sizeof(Il2CppMetadataUsageList);
-	for (int i = 0; i < usagePairCount; i++) {
+	int metholdUsageListsCount = s_GlobalMetadataHeader->metadataUsageListsCount / sizeof(Il2CppMetadataUsageList);
+	for (int i = 0; i < metholdUsageListsCount; i++) {
 		InitializeMethodMetadata(i);
 	}
 


### PR DESCRIPTION
Both count values are equel for same sizeof(), so there is no problem at runtime